### PR TITLE
Pipeline refactor

### DIFF
--- a/cloud_aggregator/ingest/ingest.py
+++ b/cloud_aggregator/ingest/ingest.py
@@ -1,4 +1,4 @@
-from pipeline import PipelineContext
+from ingest_tools.pipeline import PipelineContext
 from ingest_tools.fvcom import FVCOM_Pipeline
 from ingest_tools.nos_ofs import NOS_Pipeline
 from ingest_tools.rtofs import RTOFS_Pipeline

--- a/cloud_aggregator/ingest/ingest.py
+++ b/cloud_aggregator/ingest/ingest.py
@@ -23,7 +23,11 @@ def handler(event, context):
 
     context = PipelineContext(region, DESTINATION_BUCKET_NAME)
 
+    # TODO: These could get auto-registered
     context.add_pipeline('nos_roms', NOS_Pipeline())
     context.add_pipeline('fvcom', FVCOM_Pipeline())
     context.add_pipeline('rtofs', RTOFS_Pipeline())
-    context.run(bucket, key)
+
+    matching = context.get_matching_pipelines(key)
+    for pipeline in matching:
+        pipeline.run(context.get_region(), bucket, key, context.get_dest_bucket())    

--- a/cloud_aggregator/ingest/ingest.py
+++ b/cloud_aggregator/ingest/ingest.py
@@ -1,19 +1,12 @@
 from pipeline import PipelineContext
-from pipeline import Pipeline
-from ingest_tools.nos_ofs import generate_nos_outpu1t_key
-from ingest_tools.rtofs import generate_kerchunked_rtofs_nc
+from ingest_tools.fvcom import FVCOM_Pipeline
+from ingest_tools.nos_ofs import NOS_Pipeline
+from ingest_tools.rtofs import RTOFS_Pipeline
 from ingest_tools.aws import parse_s3_sqs_payload
-from ingest_tools.filters import key_contains
-from ingest_tools.generic import generate_kerchunked_hdf, generate_kerchunked_netcdf
 
 
 # TODO: Make these configurable
 DESTINATION_BUCKET_NAME='nextgen-dmac-cloud-ingest'
-NOS_DESTINATION_PREFIX='nos'
-RTOFS_DESTINATION_PREFIX='rtofs'
-NOS_ROMS_FILTERS= ['cbofs', 'ciofs', 'dbofs', 'tbofs', 'wcofs']
-NOS_FVCOM_FILTERS = ['ngofs2']
-RTOFS_FILTERS = ['rtofs']
 
 def handler(event, context):
     '''
@@ -28,20 +21,9 @@ def handler(event, context):
 
     region, bucket, key = parse_s3_sqs_payload(payload)
 
-    context = PipelineContext(DESTINATION_BUCKET_NAME, NOS_DESTINATION_PREFIX)
+    context = PipelineContext(region, DESTINATION_BUCKET_NAME)
 
-    context.add_pipeline('nos_roms', Pipeline('.nc', NOS_ROMS_FILTERS))
-    context.add_pipeline('fvcom', Pipeline('.nc', NOS_FVCOM_FILTERS))
-    context.add_pipeline('rtofs', Pipeline('.nc', RTOFS_FILTERS))
+    context.add_pipeline('nos_roms', NOS_Pipeline())
+    context.add_pipeline('fvcom', FVCOM_Pipeline())
+    context.add_pipeline('rtofs', RTOFS_Pipeline())
     context.run(bucket, key)
-
-    if key_contains(key, NOS_ROMS_FILTERS):
-        output_key = generate_nos_output_key(key)
-        generate_kerchunked_hdf(bucket, key, output_key, DESTINATION_BUCKET_NAME, NOS_DESTINATION_PREFIX)
-    elif key_contains(key, NOS_FVCOM_FILTERS):
-        output_key = generate_nos_output_key(key)
-        generate_kerchunked_netcdf(bucket, key, output_key, DESTINATION_BUCKET_NAME, NOS_DESTINATION_PREFIX)
-    elif key_contains(key, RTOFS_FILTERS):
-        generate_kerchunked_rtofs_nc(region, bucket, key, DESTINATION_BUCKET_NAME, RTOFS_DESTINATION_PREFIX)
-    else:
-        print(f'No ingest available for key: {key}')

--- a/cloud_aggregator/ingest/pipeline.py
+++ b/cloud_aggregator/ingest/pipeline.py
@@ -1,0 +1,58 @@
+from abc import ABC, abstractmethod
+import typing
+
+from ingest_tools.ingest_tools.filters import key_contains
+
+
+class PipelineContext():
+
+    def __init__(self, dest_bucket: str, dest_prefix: str) -> None:
+        self.dest_bucket = dest_bucket
+        self.dest_prefix = dest_prefix
+        self.pipelines = {}
+
+    def get_dest_bucket(self) -> str:
+        return self.dest_bucket
+    
+    def get_dest_prefix(self) -> str:
+        return self.dest_prefix
+    
+    def add_pipeline(self, name: str, pipeline):
+        self.pipelines[name] = pipeline
+
+    def run(self, bucket: str, key: str):        
+        for p in self.pipelines:        
+            pipeline = self.pipelines[p]
+            if pipeline.accepts(key):
+                pipeline.run(bucket, key)
+
+
+class Pipeline(ABC):
+
+    def __init__(self, fileformat: str, filters: typing.List[str]) -> None:
+        self.fileformat = fileformat
+        self.filters = filters
+    
+    def accepts(self, key) -> bool:
+        # The pipeline must accept the fileformat input
+        if not key.endswith(self.fileformat):
+            print(f'No ingest available for key: {key}')
+            return False
+        
+        # The pipeline's message filters must match
+        if key_contains(key, self.filters):
+            return True
+        
+        return False
+    
+    def run(self, src_bucket: str, src_key: str, dest_bucket: str, dest_prefix: str):
+        dest_key = self.generate_output_key(src_key)
+        self.generate_kerchunk(src_bucket, src_key, dest_key, dest_bucket, dest_prefix)
+    
+    @abstractmethod
+    def generate_output_key(self, src_key: str):
+        pass
+
+    @abstractmethod
+    def generate_kerchunk(self, src_bucket: str, src_key: str, dest_bucket: str, dest_prefix: str):
+        pass

--- a/cloud_aggregator/ingest/pipeline.py
+++ b/cloud_aggregator/ingest/pipeline.py
@@ -6,32 +6,33 @@ from ingest_tools.ingest_tools.filters import key_contains
 
 class PipelineContext():
 
-    def __init__(self, dest_bucket: str, dest_prefix: str) -> None:
+    def __init__(self, region: str, dest_bucket: str) -> None:
+        self.region = region
         self.dest_bucket = dest_bucket
-        self.dest_prefix = dest_prefix
         self.pipelines = {}
 
+    def get_region(self) -> str:
+        return self.region
+    
     def get_dest_bucket(self) -> str:
         return self.dest_bucket
-    
-    def get_dest_prefix(self) -> str:
-        return self.dest_prefix
     
     def add_pipeline(self, name: str, pipeline):
         self.pipelines[name] = pipeline
 
-    def run(self, bucket: str, key: str):        
+    def run(self, src_bucket: str, key: str):        
         for p in self.pipelines:        
             pipeline = self.pipelines[p]
             if pipeline.accepts(key):
-                pipeline.run(bucket, key)
+                pipeline.run(self, src_bucket, key)
 
 
 class Pipeline(ABC):
 
-    def __init__(self, fileformat: str, filters: typing.List[str]) -> None:
+    def __init__(self, fileformat: str, filters: typing.List[str], dest_prefix: str) -> None:
         self.fileformat = fileformat
         self.filters = filters
+        self.dest_prefix = dest_prefix
     
     def accepts(self, key) -> bool:
         # The pipeline must accept the fileformat input
@@ -45,14 +46,14 @@ class Pipeline(ABC):
         
         return False
     
-    def run(self, src_bucket: str, src_key: str, dest_bucket: str, dest_prefix: str):
+    def run(self, context: PipelineContext, src_bucket: str, src_key: str):
         dest_key = self.generate_output_key(src_key)
-        self.generate_kerchunk(src_bucket, src_key, dest_key, dest_bucket, dest_prefix)
+        self.generate_kerchunk(src_bucket, src_key, dest_key, context.get_dest_bucket(), self.dest_prefix)
     
     @abstractmethod
-    def generate_output_key(self, src_key: str):
+    def generate_output_key(self, src_key: str) -> str:
         pass
 
     @abstractmethod
-    def generate_kerchunk(self, src_bucket: str, src_key: str, dest_bucket: str, dest_prefix: str):
+    def generate_kerchunk(self, region: str, src_bucket: str, src_key: str, dest_bucket: str, dest_key: str, dest_prefix: str):
         pass

--- a/ingest_tools/ingest_tools/fvcom.py
+++ b/ingest_tools/ingest_tools/fvcom.py
@@ -1,0 +1,14 @@
+from cloud_aggregator.ingest.pipeline import Pipeline
+from .generic import generate_kerchunked_netcdf, generate_nos_output_key
+
+
+class FVCOM_Pipeline(Pipeline):
+
+    def __init__(self) -> None:
+        super().__init__('.nc', ['ngofs2'], 'nos')
+
+    def generate_output_key(self, src_key: str) -> str:
+        return generate_nos_output_key(src_key)
+
+    def generate_kerchunk(self, region: str, src_bucket: str, src_key: str, dest_bucket: str, dest_key: str, dest_prefix: str):
+        generate_kerchunked_netcdf(src_bucket, src_key, dest_key, dest_bucket, dest_prefix)

--- a/ingest_tools/ingest_tools/fvcom.py
+++ b/ingest_tools/ingest_tools/fvcom.py
@@ -1,5 +1,6 @@
-from ingest_tools.ingest_tools.pipeline import Pipeline
-from .generic import generate_kerchunked_netcdf, generate_nos_output_key
+from ingest_tools.pipeline import Pipeline
+from .generic import generate_kerchunked_netcdf
+from .nos_ofs import generate_nos_output_key
 
 
 class FVCOM_Pipeline(Pipeline):

--- a/ingest_tools/ingest_tools/fvcom.py
+++ b/ingest_tools/ingest_tools/fvcom.py
@@ -1,4 +1,4 @@
-from cloud_aggregator.ingest.pipeline import Pipeline
+from ingest_tools.ingest_tools.pipeline import Pipeline
 from .generic import generate_kerchunked_netcdf, generate_nos_output_key
 
 

--- a/ingest_tools/ingest_tools/nos_ofs.py
+++ b/ingest_tools/ingest_tools/nos_ofs.py
@@ -4,7 +4,7 @@ from typing import List, Tuple
 
 import fsspec
 import ujson
-from cloud_aggregator.ingest.pipeline import Pipeline
+from ingest_tools.pipeline import Pipeline
 from kerchunk.combine import MultiZarrToZarr
 
 from .generic import generate_kerchunked_hdf

--- a/ingest_tools/ingest_tools/nos_ofs.py
+++ b/ingest_tools/ingest_tools/nos_ofs.py
@@ -1,12 +1,25 @@
 import re
 import datetime
-from typing import Tuple
+from typing import List, Tuple
 
 import fsspec
 import ujson
+from cloud_aggregator.ingest.pipeline import Pipeline
 from kerchunk.combine import MultiZarrToZarr
 
 from .generic import generate_kerchunked_hdf
+
+
+class NOS_Pipeline(Pipeline):
+
+    def __init__(self) -> None:
+        super().__init__('.nc', ['cbofs', 'ciofs', 'dbofs', 'tbofs', 'wcofs'], 'nos')
+
+    def generate_output_key(self, src_key: str) -> str:
+        return generate_nos_output_key(src_key)
+
+    def generate_kerchunk(self, region: str, src_bucket: str, src_key: str, dest_bucket: str, dest_key: str, dest_prefix: str):
+        generate_kerchunked_hdf(src_bucket, src_key, dest_key, dest_bucket, dest_prefix)
 
 
 def parse_nos_model_run_datestamp(key: str) -> Tuple[str, str]:

--- a/ingest_tools/ingest_tools/pipeline.py
+++ b/ingest_tools/ingest_tools/pipeline.py
@@ -3,29 +3,6 @@ import typing
 from .filters import key_contains
 
 
-class PipelineContext():
-
-    def __init__(self, region: str, dest_bucket: str) -> None:
-        self.region = region
-        self.dest_bucket = dest_bucket
-        self.pipelines = {}
-
-    def get_region(self) -> str:
-        return self.region
-    
-    def get_dest_bucket(self) -> str:
-        return self.dest_bucket
-    
-    def add_pipeline(self, name: str, pipeline):
-        self.pipelines[name] = pipeline
-
-    def run(self, src_bucket: str, key: str):        
-        for p in self.pipelines:        
-            pipeline = self.pipelines[p]
-            if pipeline.accepts(key):
-                pipeline.run(self, src_bucket, key)
-
-
 class Pipeline(ABC):
 
     def __init__(self, fileformat: str, filters: typing.List[str], dest_prefix: str) -> None:
@@ -45,9 +22,9 @@ class Pipeline(ABC):
         
         return False
     
-    def run(self, context: PipelineContext, src_bucket: str, src_key: str):
+    def run(self, src_bucket: str, src_key: str, dest_bucket: str):
         dest_key = self.generate_output_key(src_key)
-        self.generate_kerchunk(src_bucket, src_key, dest_key, context.get_dest_bucket(), self.dest_prefix)
+        self.generate_kerchunk(src_bucket, src_key, dest_key, dest_bucket, self.dest_prefix)
     
     @abstractmethod
     def generate_output_key(self, src_key: str) -> str:
@@ -56,3 +33,30 @@ class Pipeline(ABC):
     @abstractmethod
     def generate_kerchunk(self, region: str, src_bucket: str, src_key: str, dest_bucket: str, dest_key: str, dest_prefix: str):
         pass
+
+    
+class PipelineContext():
+
+    def __init__(self, region: str, dest_bucket: str) -> None:
+        self.region = region
+        self.dest_bucket = dest_bucket
+        self.pipelines = {}
+
+    def get_region(self) -> str:
+        return self.region
+    
+    def get_dest_bucket(self) -> str:
+        return self.dest_bucket
+    
+    def add_pipeline(self, name: str, pipeline):
+        self.pipelines[name] = pipeline
+
+    def get_pipelines(self, key: str) -> typing.List[Pipeline]:
+        matching = []
+        for p in self.pipelines:        
+            pipeline = self.pipelines[p]
+            if pipeline.accepts(key):
+                matching.append(pipeline)
+        if len(matching) == 0:
+            return None
+        return matching

--- a/ingest_tools/ingest_tools/pipeline.py
+++ b/ingest_tools/ingest_tools/pipeline.py
@@ -22,9 +22,9 @@ class Pipeline(ABC):
         
         return False
     
-    def run(self, src_bucket: str, src_key: str, dest_bucket: str):
+    def run(self, region: str, src_bucket: str, src_key: str, dest_bucket: str):
         dest_key = self.generate_output_key(src_key)
-        self.generate_kerchunk(src_bucket, src_key, dest_key, dest_bucket, self.dest_prefix)
+        self.generate_kerchunk(region, src_bucket, src_key, dest_bucket, dest_key, self.dest_prefix)
     
     @abstractmethod
     def generate_output_key(self, src_key: str) -> str:
@@ -48,15 +48,13 @@ class PipelineContext():
     def get_dest_bucket(self) -> str:
         return self.dest_bucket
     
-    def add_pipeline(self, name: str, pipeline):
+    def add_pipeline(self, name: str, pipeline: Pipeline):
         self.pipelines[name] = pipeline
 
-    def get_pipelines(self, key: str) -> typing.List[Pipeline]:
+    def get_matching_pipelines(self, key: str) -> typing.List[Pipeline]:
         matching = []
         for p in self.pipelines:        
             pipeline = self.pipelines[p]
             if pipeline.accepts(key):
                 matching.append(pipeline)
-        if len(matching) == 0:
-            return None
         return matching

--- a/ingest_tools/ingest_tools/pipeline.py
+++ b/ingest_tools/ingest_tools/pipeline.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 import typing
-
-from ingest_tools.ingest_tools.filters import key_contains
+from .filters import key_contains
 
 
 class PipelineContext():

--- a/ingest_tools/ingest_tools/rtofs.py
+++ b/ingest_tools/ingest_tools/rtofs.py
@@ -4,9 +4,22 @@ from typing import Tuple
 
 import fsspec
 import ujson
+from cloud_aggregator.ingest.pipeline import Pipeline
 from kerchunk.combine import MultiZarrToZarr
 
 from .generic import generate_kerchunked_hdf
+
+
+class RTOFS_Pipeline(Pipeline):
+    
+    def __init__(self) -> None:
+        super().__init__('.nc', ['rtofs'], 'rtofs')
+
+    def generate_output_key(self, src_key: str) -> str:
+        return src_key
+
+    def generate_kerchunk(self, region: str, src_bucket: str, src_key: str, dest_bucket: str, dest_key: str, dest_prefix: str):
+        generate_kerchunked_rtofs_nc(region, src_bucket, src_key, dest_bucket, dest_prefix)
 
 
 def generate_rtofs_output_key(key: str) -> str:

--- a/ingest_tools/pyproject.toml
+++ b/ingest_tools/pyproject.toml
@@ -22,6 +22,12 @@ packages = ["ingest_tools"]
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.txt"] }
 
+[tool.pytest.ini_options]
+addopts = [
+    "--import-mode=importlib",
+]
+pythonpath = ["."]
+
 [tool.check-manifest]
 ignore = [
     "*.yml",

--- a/ingest_tools/pyproject.toml
+++ b/ingest_tools/pyproject.toml
@@ -22,12 +22,6 @@ packages = ["ingest_tools"]
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.txt"] }
 
-[tool.pytest.ini_options]
-addopts = [
-    "--import-mode=importlib",
-]
-pythonpath = ["."]
-
 [tool.check-manifest]
 ignore = [
     "*.yml",

--- a/ingest_tools/pytest.ini
+++ b/ingest_tools/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/ingest_tools/tests/test_nos_ofs.py
+++ b/ingest_tools/tests/test_nos_ofs.py
@@ -65,9 +65,3 @@ def test_generate_best_time_series_glob_expression():
     key = 'nos/ngofs2/nos.ngofs2.fields.f042.20231003.t09z.nc.zarr'
     glob_expression = nos_ofs.generate_nos_best_time_series_glob_expression(key)
     assert glob_expression == 'nos/ngofs2/nos.ngofs2.fields.f*.*.t*z.nc.zarr'
-
-
-def test_generate_outputkey():
-    key = 'tbofs.20230314/nos.tbofs.fields.n002.20230314.t00z.nc'
-    output_key = nos_ofs.generate_nos_output_key(key)
-    assert output_key == 'tbofs/nos.tbofs.fields.n002.20230314.t00z.nc.zarr'

--- a/ingest_tools/tests/test_pipelines.py
+++ b/ingest_tools/tests/test_pipelines.py
@@ -28,6 +28,6 @@ def test_pipeline_context():
     context.add_pipeline('rtofs', RTOFS_Pipeline())
 
     # This test should only return the NOS Pipeline because that's what this data is
-    matching = context.get_pipelines('tbofs.20230314/nos.tbofs.fields.n002.20230314.t00z.nc')
+    matching = context.get_matching_pipelines('tbofs.20230314/nos.tbofs.fields.n002.20230314.t00z.nc')
     assert len(matching) == 1
     assert isinstance(matching[0], NOS_Pipeline)

--- a/ingest_tools/tests/test_pipelines.py
+++ b/ingest_tools/tests/test_pipelines.py
@@ -1,16 +1,22 @@
+import pytest
+from ingest_tools.fvcom import FVCOM_Pipeline
+from ingest_tools.nos_ofs import NOS_Pipeline
 from ingest_tools.pipeline import Pipeline
 from ingest_tools.rtofs import RTOFS_Pipeline
 
 
-def test_rtofs_pipeline():
-    p = RTOFS_Pipeline()
-    test_file = 'rtofs.20230922/rtofs_glo_2ds_f001_diag.nc'
-    assert_pipeline_accepts(p, test_file)
-    assert_pipeline_output_key(p, test_file, 'rtofs.20230922.rtofs_glo_2ds_f001_diag.nc.zarr')
+# TODO: This is simply a demonstration, but we can make this more robust to automatically test all available pipelines
+@pytest.mark.parametrize('test_input', [
+    [RTOFS_Pipeline(), 'rtofs.20230922/rtofs_glo_2ds_f001_diag.nc', 'rtofs.20230922.rtofs_glo_2ds_f001_diag.nc.zarr'],
+    [NOS_Pipeline(), 'tbofs.20230314/nos.tbofs.fields.n002.20230314.t00z.nc', 'tbofs/nos.tbofs.fields.n002.20230314.t00z.nc.zarr'],
+    [FVCOM_Pipeline(), 'ngofs2/nos.ngofs2.fields.f042.20231003.t09z.nc', 'ngofs2/nos.ngofs2.fields.f042.20231003.t09z.nc.zarr']
+    ])
+def test_pipelines(test_input):
+    pipeline = test_input[0]
+    test_key = test_input[1]
+    expected_key = test_input[2]
 
-def assert_pipeline_accepts(pipeline: Pipeline, test_key: str):
     assert pipeline.accepts(test_key)
-
-def assert_pipeline_output_key(pipeline: Pipeline, test_key: str, expected_key: str):
+    
     out_key = pipeline.generate_output_key(test_key)
     assert out_key == expected_key

--- a/ingest_tools/tests/test_pipelines.py
+++ b/ingest_tools/tests/test_pipelines.py
@@ -1,7 +1,7 @@
 import pytest
 from ingest_tools.fvcom import FVCOM_Pipeline
 from ingest_tools.nos_ofs import NOS_Pipeline
-from ingest_tools.pipeline import Pipeline
+from ingest_tools.pipeline import Pipeline, PipelineContext
 from ingest_tools.rtofs import RTOFS_Pipeline
 
 
@@ -20,3 +20,14 @@ def test_pipelines(test_input):
     
     out_key = pipeline.generate_output_key(test_key)
     assert out_key == expected_key
+
+
+def test_pipeline_context():
+    context = PipelineContext('us-east-1', 'nextgen-dmac')
+    context.add_pipeline('nos', NOS_Pipeline())
+    context.add_pipeline('rtofs', RTOFS_Pipeline())
+
+    # This test should only return the NOS Pipeline because that's what this data is
+    matching = context.get_pipelines('tbofs.20230314/nos.tbofs.fields.n002.20230314.t00z.nc')
+    assert len(matching) == 1
+    assert isinstance(matching[0], NOS_Pipeline)

--- a/ingest_tools/tests/test_pipelines.py
+++ b/ingest_tools/tests/test_pipelines.py
@@ -1,0 +1,16 @@
+from ingest_tools.pipeline import Pipeline
+from ingest_tools.rtofs import RTOFS_Pipeline
+
+
+def test_rtofs_pipeline():
+    p = RTOFS_Pipeline()
+    test_file = 'rtofs.20230922/rtofs_glo_2ds_f001_diag.nc'
+    assert_pipeline_accepts(p, test_file)
+    assert_pipeline_output_key(p, test_file, 'rtofs.20230922.rtofs_glo_2ds_f001_diag.nc.zarr')
+
+def assert_pipeline_accepts(pipeline: Pipeline, test_key: str):
+    assert pipeline.accepts(test_key)
+
+def assert_pipeline_output_key(pipeline: Pipeline, test_key: str, expected_key: str):
+    out_key = pipeline.generate_output_key(test_key)
+    assert out_key == expected_key

--- a/ingest_tools/tests/test_rtofs.py
+++ b/ingest_tools/tests/test_rtofs.py
@@ -1,10 +1,4 @@
-from ingest_tools.rtofs import generate_rtofs_output_key, generate_rtofs_best_time_series_glob_expression, parse_rtofs_model_run_datestamp_offset, generate_rtofs_best_timeseries_key
-
-
-def test_generate_rtofs_output_key():
-    key = 'rtofs.20230922/rtofs_glo_2ds_f001_diag.nc'
-    output_key = generate_rtofs_output_key(key) 
-    assert output_key == 'rtofs.20230922.rtofs_glo_2ds_f001_diag.nc.zarr'
+from ingest_tools.rtofs import generate_rtofs_best_time_series_glob_expression, parse_rtofs_model_run_datestamp_offset, generate_rtofs_best_timeseries_key
 
 
 def test_generate_rtofs_best_time_series_glob_expression():


### PR DESCRIPTION
Created a structure for executing pipelines. This takes boilerplate code out of ingest.py and allows the logic to be defined in specific class implementations for each type of model (e.g. NOS, FVCOM, RTOFS). This will allow us to add more pipelines as necessary without reimplementing the execution or testing of each individual one.

**I haven't tested the new ingest.py in production yet.**

Future implementation plans include moving additional logic into the appropriate pipelines, perhaps creating a command object to encapsulate src/dest/region data, and maybe auto-registering pipelines like we can with plugins in xpublish. Integration with Pulumi may be nice too so each pipeline automatically creates its own infrastructure.

This also creates building blocks that can be extended with additional functionality for all pipelines such as logging/monitoring, retries, etc. This may or may not be useful for generating STAC items as well, TBD. That should probably go in its own subsystem.